### PR TITLE
Improving "Part Movement Between Shards" with signals

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -197,7 +197,6 @@ struct Settings;
     /** Experimental/work in progress feature. Unsafe for production. */ \
     M(UInt64, part_moves_between_shards_enable, 0, "Experimental/Incomplete feature to move parts between shards. Does not take into account sharding expressions.", 0) \
     M(UInt64, part_moves_between_shards_delay_seconds, 30, "Time to wait before/after moving parts between shards.", 0) \
-    M(Bool, disable_quorum_check_move_parts, false, "Disable quorum check for moving parts between replicas, mostly inteded for testing", 0) \
     M(Bool, allow_remote_fs_zero_copy_replication, false, "Don't use this setting in production, because it is not ready.", 0) \
     M(String, remote_fs_zero_copy_zookeeper_path, "/clickhouse/zero_copy", "ZooKeeper path for zero-copy table-independent info.", 0) \
     M(Bool, remote_fs_zero_copy_path_compatible_mode, false, "Run zero-copy in compatible mode during conversion process.", 0) \

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -197,6 +197,7 @@ struct Settings;
     /** Experimental/work in progress feature. Unsafe for production. */ \
     M(UInt64, part_moves_between_shards_enable, 0, "Experimental/Incomplete feature to move parts between shards. Does not take into account sharding expressions.", 0) \
     M(UInt64, part_moves_between_shards_delay_seconds, 30, "Time to wait before/after moving parts between shards.", 0) \
+    M(Bool, disable_quorum_check_move_parts, false, "Disable quorum check for moving parts between replicas, mostly inteded for testing", 0) \
     M(Bool, allow_remote_fs_zero_copy_replication, false, "Don't use this setting in production, because it is not ready.", 0) \
     M(String, remote_fs_zero_copy_zookeeper_path, "/clickhouse/zero_copy", "ZooKeeper path for zero-copy table-independent info.", 0) \
     M(Bool, remote_fs_zero_copy_path_compatible_mode, false, "Run zero-copy in compatible mode during conversion process.", 0) \

--- a/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
+++ b/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
@@ -46,9 +46,9 @@ void PartMovesBetweenShardsOrchestrator::run()
 
     try
     {
-        if(storage.is_leader){
+        if (storage.is_leader){
             std::optional<Entry> selected_entry = selectEntryFromZk();
-            if(selected_entry.has_value()){
+            if (selected_entry.has_value()){
                 /// Schedule for immediate re-execution as likely there is more work
                 /// to be done.
                 step(selected_entry.value());
@@ -104,7 +104,7 @@ std::optional<PartMovesBetweenShardsOrchestrator::Entry> PartMovesBetweenShardsO
 
     Strings signaled_entries = zk->getChildren(entries_znode_path + "/task_queue");
 
-    for(String & signaled_entry : signaled_entries){
+    for (String & signaled_entry : signaled_entries){
         Entry entry_to_process;
         Coordination::Stat stat;
         entry_to_process.znode_path = entries_znode_path + "/tasks/" + signaled_entry;
@@ -143,9 +143,9 @@ void PartMovesBetweenShardsOrchestrator::step(Entry & entry)
 
     EntryState current_state = entry.state;
 
-    if(!entry.rollback){
+    if (!entry.rollback){
         entry.state = getNextState(entry);
-        if(entry.state.value == current_state.value)
+        if (entry.state.value == current_state.value)
         {
            throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot process the step entry with out quorum success for state {}", entry.state.value);
         }
@@ -177,7 +177,7 @@ void PartMovesBetweenShardsOrchestrator::step(Entry & entry)
 
 PartMovesBetweenShardsOrchestrator::EntryState PartMovesBetweenShardsOrchestrator::getNextState(Entry & entry) const
 {
-    if(entry.state.value == EntryState::TODO  || entry.replicas.size() == entry.required_number_of_replicas ){
+    if (entry.state.value == EntryState::TODO  || entry.replicas.size() == entry.required_number_of_replicas){
         return EntryState::nextState(entry.state.value);
     }
 
@@ -642,9 +642,10 @@ void PartMovesBetweenShardsOrchestrator::Entry::fromString(const String & buf)
     replicas = parseFromString<std::vector<String>>(json->getValue<std::string>(JSON_KEY_REPLICAS));
 }
 
-UInt64 PartMovesBetweenShardsOrchestrator::getQuorum(String zk_path){
+UInt64 PartMovesBetweenShardsOrchestrator::getQuorum(String zk_path)
+{
     auto zk = storage.getZooKeeper();
-    Strings replicas = zk->getChildren( fs::path(zk_path) / "replicas");
+    Strings replicas = zk->getChildren(fs::path(zk_path) / "replicas");
     return replicas.size();
 }
 }

--- a/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
+++ b/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
@@ -100,7 +100,6 @@ std::vector<PartMovesBetweenShardsOrchestrator::Entry> PartMovesBetweenShardsOrc
 std::optional<PartMovesBetweenShardsOrchestrator::Entry> PartMovesBetweenShardsOrchestrator::selectEntryFromZk()
 {
     std::lock_guard lock(state_mutex);
-    
     auto zk = storage.getZooKeeper();
 
     Strings signaled_entries = zk->getChildren(entries_znode_path + "/task_queue");
@@ -111,13 +110,9 @@ std::optional<PartMovesBetweenShardsOrchestrator::Entry> PartMovesBetweenShardsO
         Entry entry_to_process;
        
         Coordination::Stat stat;
-
         entry_to_process.znode_path = entries_znode_path + "/tasks/" + signaled_entry;
-
         auto entry_str = zk->get(entry_to_process.znode_path, &stat);
-
         entry_to_process.fromString(entry_str);
-
         entry_to_process.version = stat.version;
         entry_to_process.znode_name = signaled_entry;
 
@@ -135,7 +130,6 @@ std::optional<PartMovesBetweenShardsOrchestrator::Entry> PartMovesBetweenShardsO
                 throw;
             }
         }
-        
     }
     return std::nullopt;
 }
@@ -143,7 +137,6 @@ std::optional<PartMovesBetweenShardsOrchestrator::Entry> PartMovesBetweenShardsO
 void PartMovesBetweenShardsOrchestrator::step(Entry & entry)
 {
     auto zk = storage.getZooKeeper();
-
 
     LOG_DEBUG(log, "stepEntry on task {} from state {} (rollback: {}), try: {}",
               entry.znode_name,
@@ -160,7 +153,6 @@ void PartMovesBetweenShardsOrchestrator::step(Entry & entry)
            throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot process the step entry with out quorum success for state {}", entry.state.value);
         } 
     }
-    
     Coordination::Requests ops;
 
     try
@@ -281,7 +273,6 @@ void PartMovesBetweenShardsOrchestrator::stepEntry(Entry & entry)
                 Coordination::Responses responses;
                 Coordination::Error rc = zk->tryMulti(ops, responses);
                 zkutil::KeeperMultiException::check(rc, ops, responses);
-
                 LOG_DEBUG(log, "Pushed log entry for task {} and state {}", entry.znode_name, entry.state.toString());  
             }
             break;
@@ -289,7 +280,6 @@ void PartMovesBetweenShardsOrchestrator::stepEntry(Entry & entry)
 
         case EntryState::DESTINATION_FETCH:
         {
-
             if (entry.rollback)
             {
                 // TODO(nv): Do we want to cleanup fetched data on the destination?

--- a/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
+++ b/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
@@ -21,7 +21,6 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
     extern const int TIMEOUT_EXCEEDED;
-    extern const int NO_AVAILABLE_REPLICA;
 }
 
 PartMovesBetweenShardsOrchestrator::PartMovesBetweenShardsOrchestrator(StorageReplicatedMergeTree & storage_)

--- a/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
+++ b/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
@@ -46,9 +46,11 @@ void PartMovesBetweenShardsOrchestrator::run()
 
     try
     {
-        if (storage.is_leader){
+        if (storage.is_leader)
+        {
             std::optional<Entry> selected_entry = selectEntryFromZk();
-            if (selected_entry.has_value()){
+            if (selected_entry.has_value())
+            {
                 /// Schedule for immediate re-execution as likely there is more work
                 /// to be done.
                 step(selected_entry.value());
@@ -104,7 +106,8 @@ std::optional<PartMovesBetweenShardsOrchestrator::Entry> PartMovesBetweenShardsO
 
     Strings signaled_entries = zk->getChildren(entries_znode_path + "/task_queue");
 
-    for (String & signaled_entry : signaled_entries){
+    for (String & signaled_entry : signaled_entries)
+    {
         Entry entry_to_process;
         Coordination::Stat stat;
         entry_to_process.znode_path = entries_znode_path + "/tasks/" + signaled_entry;
@@ -123,7 +126,8 @@ std::optional<PartMovesBetweenShardsOrchestrator::Entry> PartMovesBetweenShardsO
             if (e.code == Coordination::Error::ZNODEEXISTS)
             {
                 LOG_DEBUG(log, "Task {} is being processed by another replica", entry_to_process.znode_name);
-            } else {
+            } else 
+            {
                 throw;
             }
         }
@@ -143,7 +147,8 @@ void PartMovesBetweenShardsOrchestrator::step(Entry & entry)
 
     EntryState current_state = entry.state;
 
-    if (!entry.rollback){
+    if (!entry.rollback)
+    {
         entry.state = getNextState(entry);
         if (entry.state.value == current_state.value)
         {
@@ -177,10 +182,10 @@ void PartMovesBetweenShardsOrchestrator::step(Entry & entry)
 
 PartMovesBetweenShardsOrchestrator::EntryState PartMovesBetweenShardsOrchestrator::getNextState(Entry & entry) const
 {
-    if (entry.state.value == EntryState::TODO  || entry.replicas.size() == entry.required_number_of_replicas){
+    if (entry.state.value == EntryState::TODO  || entry.replicas.size() == entry.required_number_of_replicas)
+    {
         return EntryState::nextState(entry.state.value);
     }
-
     return entry.state;
 }
 

--- a/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
+++ b/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
@@ -104,7 +104,6 @@ std::optional<PartMovesBetweenShardsOrchestrator::Entry> PartMovesBetweenShardsO
 
     Strings signaled_entries = zk->getChildren(entries_znode_path + "/task_queue");
 
-
     for(String & signaled_entry : signaled_entries){
         Entry entry_to_process;
         Coordination::Stat stat;
@@ -113,7 +112,7 @@ std::optional<PartMovesBetweenShardsOrchestrator::Entry> PartMovesBetweenShardsO
         entry_to_process.fromString(entry_str);
         entry_to_process.version = stat.version;
         entry_to_process.znode_name = signaled_entry;
-        
+
         try
         {
             zk->create(entry_to_process.znode_path + "/replica", storage.replica_name, zkutil::CreateMode::Ephemeral);

--- a/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
+++ b/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
@@ -106,16 +106,14 @@ std::optional<PartMovesBetweenShardsOrchestrator::Entry> PartMovesBetweenShardsO
 
 
     for(String & signaled_entry : signaled_entries){
-
         Entry entry_to_process;
-       
         Coordination::Stat stat;
         entry_to_process.znode_path = entries_znode_path + "/tasks/" + signaled_entry;
         auto entry_str = zk->get(entry_to_process.znode_path, &stat);
         entry_to_process.fromString(entry_str);
         entry_to_process.version = stat.version;
         entry_to_process.znode_name = signaled_entry;
-
+        
         try
         {
             zk->create(entry_to_process.znode_path + "/replica", storage.replica_name, zkutil::CreateMode::Ephemeral);
@@ -151,7 +149,7 @@ void PartMovesBetweenShardsOrchestrator::step(Entry & entry)
         if(entry.state.value == current_state.value)
         {
            throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot process the step entry with out quorum success for state {}", entry.state.value);
-        } 
+        }
     }
     Coordination::Requests ops;
 
@@ -273,7 +271,7 @@ void PartMovesBetweenShardsOrchestrator::stepEntry(Entry & entry)
                 Coordination::Responses responses;
                 Coordination::Error rc = zk->tryMulti(ops, responses);
                 zkutil::KeeperMultiException::check(rc, ops, responses);
-                LOG_DEBUG(log, "Pushed log entry for task {} and state {}", entry.znode_name, entry.state.toString());  
+                LOG_DEBUG(log, "Pushed log entry for task {} and state {}", entry.znode_name, entry.state.toString());
             }
             break;
         }

--- a/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
+++ b/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
@@ -126,7 +126,8 @@ std::optional<PartMovesBetweenShardsOrchestrator::Entry> PartMovesBetweenShardsO
             if (e.code == Coordination::Error::ZNODEEXISTS)
             {
                 LOG_DEBUG(log, "Task {} is being processed by another replica", entry_to_process.znode_name);
-            } else 
+            }
+            else
             {
                 throw;
             }
@@ -182,7 +183,7 @@ void PartMovesBetweenShardsOrchestrator::step(Entry & entry)
 
 PartMovesBetweenShardsOrchestrator::EntryState PartMovesBetweenShardsOrchestrator::getNextState(Entry & entry) const
 {
-    if (entry.state.value == EntryState::TODO  || entry.replicas.size() == entry.required_number_of_replicas)
+    if (entry.state.value == EntryState::TODO || entry.replicas.size() == entry.required_number_of_replicas)
     {
         return EntryState::nextState(entry.state.value);
     }

--- a/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.h
+++ b/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <unordered_set>
 #include <base/types.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Core/UUID.h>
@@ -54,9 +55,7 @@ public:
             SYNC_DESTINATION,
             DESTINATION_FETCH,
             DESTINATION_ATTACH,
-            SOURCE_DROP_PRE_DELAY,
             SOURCE_DROP,
-            SOURCE_DROP_POST_DELAY,
             REMOVE_UUID_PIN,
             DONE,
         };
@@ -75,9 +74,7 @@ public:
                 case SYNC_DESTINATION: return "SYNC_DESTINATION";
                 case DESTINATION_FETCH: return "DESTINATION_FETCH";
                 case DESTINATION_ATTACH: return "DESTINATION_ATTACH";
-                case SOURCE_DROP_PRE_DELAY: return "SOURCE_DROP_PRE_DELAY";
                 case SOURCE_DROP: return "SOURCE_DROP";
-                case SOURCE_DROP_POST_DELAY: return "SOURCE_DROP_POST_DELAY";
                 case REMOVE_UUID_PIN: return "REMOVE_UUID_PIN";
                 case DONE: return "DONE";
                 case CANCELLED: return "CANCELLED";
@@ -93,13 +90,28 @@ public:
             else if (in == "SYNC_DESTINATION") return SYNC_DESTINATION;
             else if (in == "DESTINATION_FETCH") return DESTINATION_FETCH;
             else if (in == "DESTINATION_ATTACH") return DESTINATION_ATTACH;
-            else if (in == "SOURCE_DROP_PRE_DELAY") return SOURCE_DROP_PRE_DELAY;
             else if (in == "SOURCE_DROP") return SOURCE_DROP;
-            else if (in == "SOURCE_DROP_POST_DELAY") return SOURCE_DROP_POST_DELAY;
             else if (in == "REMOVE_UUID_PIN") return REMOVE_UUID_PIN;
             else if (in == "DONE") return DONE;
             else if (in == "CANCELLED") return CANCELLED;
             else throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown state: {}", in);
+        }
+
+        static EntryState::Value nextState(EntryState::Value state)
+        {
+            switch (state)
+            {
+                case TODO: return SYNC_SOURCE;
+                case SYNC_SOURCE: return SYNC_DESTINATION;
+                case SYNC_DESTINATION: return DESTINATION_FETCH;
+                case DESTINATION_FETCH: return DESTINATION_ATTACH;
+                case DESTINATION_ATTACH: return SOURCE_DROP;
+                case SOURCE_DROP: return REMOVE_UUID_PIN;
+                case REMOVE_UUID_PIN: return DONE;
+                case DONE: return DONE;
+                case CANCELLED: return CANCELLED;
+            }
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown EntryState: {}", DB::toString<int>(state));
         }
     };
 
@@ -118,6 +130,9 @@ public:
         UUID part_uuid;
         String to_shard;
         String dst_part_name;
+
+        size_t required_number_of_replicas{};
+        std::set<String> replicas;
 
         EntryState state;
         bool rollback = false;
@@ -171,6 +186,7 @@ private:
     Entry getEntryByUUID(const UUID & task_uuid);
     void removePins(const Entry & entry, zkutil::ZooKeeperPtr zk);
     void syncStateFromZK();
+    EntryState getNextState(Entry entry);
 
     StorageReplicatedMergeTree & storage;
 
@@ -183,6 +199,7 @@ private:
 
     mutable std::mutex state_mutex;
     std::vector<Entry> entries;
+    std::unordered_set<String> signaled_entries;
 
 public:
     String entries_znode_path;

--- a/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.h
+++ b/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <set>
 #include <vector>
-#include <unordered_set>
 #include <base/types.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
+#include "Core/Types.h"
 #include <Core/UUID.h>
 #include <Core/BackgroundSchedulePool.h>
 #include <IO/WriteHelpers.h>
@@ -131,8 +132,9 @@ public:
         String to_shard;
         String dst_part_name;
 
-        size_t required_number_of_replicas{};
-        std::set<String> replicas;
+        UInt64 required_number_of_replicas;
+        std::set<String> replicas_success;
+        std::set<String> replicas_failed;
 
         EntryState state;
         bool rollback = false;
@@ -166,6 +168,9 @@ private:
     static constexpr auto JSON_KEY_ROLLBACK = "rollback";
     static constexpr auto JSON_KEY_LAST_EX_MSG = "last_exception";
     static constexpr auto JSON_KEY_NUM_TRIES = "num_tries";
+    static constexpr auto JSON_KEY_REQUIRED_NUM_REPLICAS = "required_number_of_replicas";
+    static constexpr auto JSON_KEY_REPLICAS_SUCCESS = "replicas_success";
+    static constexpr auto JSON_KEY_REPLICAS_FAILED = "replicas_failed";
 
 public:
     explicit PartMovesBetweenShardsOrchestrator(StorageReplicatedMergeTree & storage_);
@@ -180,13 +185,15 @@ public:
 
 private:
     void run();
-    bool step();
-    Entry stepEntry(Entry entry, zkutil::ZooKeeperPtr zk);
+    void step(Entry & entry);
+    void stepEntry(Entry & entry, zkutil::ZooKeeperPtr zk);
 
     Entry getEntryByUUID(const UUID & task_uuid);
-    void removePins(const Entry & entry, zkutil::ZooKeeperPtr zk);
-    void syncStateFromZK();
-    EntryState getNextState(Entry entry);
+    void removePins(Entry & entry,zkutil::ZooKeeperPtr zk);
+    std::vector<PartMovesBetweenShardsOrchestrator::Entry> getEntriesFromZk();
+    std::optional<PartMovesBetweenShardsOrchestrator::Entry> selectEntryFromZk();
+
+    EntryState getNextState(Entry & entry) const;
 
     StorageReplicatedMergeTree & storage;
 
@@ -198,8 +205,6 @@ private:
     BackgroundSchedulePool::TaskHolder task;
 
     mutable std::mutex state_mutex;
-    std::vector<Entry> entries;
-    std::unordered_set<String> signaled_entries;
 
 public:
     String entries_znode_path;

--- a/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.h
+++ b/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <set>
+
 #include <vector>
 #include <base/types.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
-#include "Core/Types.h"
 #include <Core/UUID.h>
 #include <Core/BackgroundSchedulePool.h>
 #include <IO/WriteHelpers.h>
@@ -133,8 +132,7 @@ public:
         String dst_part_name;
 
         UInt64 required_number_of_replicas;
-        std::set<String> replicas_success;
-        std::set<String> replicas_failed;
+        std::vector<String> replicas;
 
         EntryState state;
         bool rollback = false;
@@ -169,8 +167,7 @@ private:
     static constexpr auto JSON_KEY_LAST_EX_MSG = "last_exception";
     static constexpr auto JSON_KEY_NUM_TRIES = "num_tries";
     static constexpr auto JSON_KEY_REQUIRED_NUM_REPLICAS = "required_number_of_replicas";
-    static constexpr auto JSON_KEY_REPLICAS_SUCCESS = "replicas_success";
-    static constexpr auto JSON_KEY_REPLICAS_FAILED = "replicas_failed";
+    static constexpr auto JSON_KEY_REPLICAS = "replicas";
 
 public:
     explicit PartMovesBetweenShardsOrchestrator(StorageReplicatedMergeTree & storage_);
@@ -186,7 +183,7 @@ public:
 private:
     void run();
     void step(Entry & entry);
-    void stepEntry(Entry & entry, zkutil::ZooKeeperPtr zk);
+    void stepEntry(Entry & entry);
 
     Entry getEntryByUUID(const UUID & task_uuid);
     void removePins(Entry & entry,zkutil::ZooKeeperPtr zk);
@@ -194,6 +191,7 @@ private:
     std::optional<PartMovesBetweenShardsOrchestrator::Entry> selectEntryFromZk();
 
     EntryState getNextState(Entry & entry) const;
+    UInt64 getQuorum(String zk_path);
 
     StorageReplicatedMergeTree & storage;
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp
@@ -195,7 +195,7 @@ void ReplicatedMergeTreeAttachThread::runImpl()
     storage.clearOldTemporaryDirectories(0, {"tmp_", "delete_tmp_", "tmp-fetch_"});
 
     storage.createNewZooKeeperNodes();
-    storage.syncPinnedPartUUIDs();
+    storage.syncPinnedPartUUIDs(true);
 
     std::lock_guard lock(storage.table_shared_id_mutex);
     storage.createTableSharedID();

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
@@ -185,7 +185,6 @@ void ReplicatedMergeTreeLogEntryData::writeText(WriteBuffer & out) const
 
     if(!task_name.empty())
         out << "task_name: " << task_name << "\n";
-    
     if(!task_entry_zk_path.empty())
         out << "task_entry_zk_path: " << task_entry_zk_path << "\n";
 }
@@ -391,7 +390,6 @@ void ReplicatedMergeTreeLogEntryData::readText(ReadBuffer & in, MergeTreeDataFor
 
     if(!in.eof() && checkString("task_entry_zk_path: ", in))
             in >>  task_entry_zk_path >> "\n";
-
 }
 
 void ReplicatedMergeTreeLogEntryData::ReplaceRangeEntry::writeText(WriteBuffer & out) const

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
@@ -380,7 +380,6 @@ void ReplicatedMergeTreeLogEntryData::readText(ReadBuffer & in, MergeTreeDataFor
     }
     else
         new_part_format.storage_type = MergeTreeDataPartStorageType::Full;
-    
     /// Optional field.
     if (!in.eof() && checkString("quorum: ", in))
             in >>  quorum >> "\n";

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
@@ -181,7 +181,13 @@ void ReplicatedMergeTreeLogEntryData::writeText(WriteBuffer & out) const
         out << "storage_type: " << storage_type.toString() << "\n";
 
     if (quorum)
-        out << "quorum: " << quorum << '\n';
+        out << "quorum: " << quorum << "\n";
+
+    if(!task_name.empty())
+        out << "task_name: " << task_name << "\n";
+    
+    if(!task_entry_zk_path.empty())
+        out << "task_entry_zk_path: " << task_entry_zk_path << "\n";
 }
 
 void ReplicatedMergeTreeLogEntryData::readText(ReadBuffer & in, MergeTreeDataFormatVersion partition_format_version)
@@ -375,10 +381,17 @@ void ReplicatedMergeTreeLogEntryData::readText(ReadBuffer & in, MergeTreeDataFor
     }
     else
         new_part_format.storage_type = MergeTreeDataPartStorageType::Full;
-
+    
     /// Optional field.
-    if (!in.eof())
-        in >> "quorum: " >> quorum >> "\n";
+    if (!in.eof() && checkString("quorum: ", in))
+            in >>  quorum >> "\n";
+
+    if(!in.eof() && checkString("task_name: ", in))
+            in >> task_name >> "\n";
+
+    if(!in.eof() && checkString("task_entry_zk_path: ", in))
+            in >>  task_entry_zk_path >> "\n";
+
 }
 
 void ReplicatedMergeTreeLogEntryData::ReplaceRangeEntry::writeText(WriteBuffer & out) const

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
@@ -183,9 +183,9 @@ void ReplicatedMergeTreeLogEntryData::writeText(WriteBuffer & out) const
     if (quorum)
         out << "quorum: " << quorum << "\n";
 
-    if(!task_name.empty())
+    if (!task_name.empty())
         out << "task_name: " << task_name << "\n";
-    if(!task_entry_zk_path.empty())
+    if (!task_entry_zk_path.empty())
         out << "task_entry_zk_path: " << task_entry_zk_path << "\n";
 }
 
@@ -384,10 +384,10 @@ void ReplicatedMergeTreeLogEntryData::readText(ReadBuffer & in, MergeTreeDataFor
     if (!in.eof() && checkString("quorum: ", in))
             in >>  quorum >> "\n";
 
-    if(!in.eof() && checkString("task_name: ", in))
+    if (!in.eof() && checkString("task_name: ", in))
             in >> task_name >> "\n";
 
-    if(!in.eof() && checkString("task_entry_zk_path: ", in))
+    if (!in.eof() && checkString("task_entry_zk_path: ", in))
             in >>  task_entry_zk_path >> "\n";
 }
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
@@ -107,6 +107,10 @@ struct ReplicatedMergeTreeLogEntryData
     /// For DROP_RANGE, true means that the parts need not be deleted, but moved to the `detached` directory.
     bool detach = false;
 
+    /// For MOVE_PART operation, task that initiated this action
+    String task_name;
+    String task_entry_zk_path;
+
     /// REPLACE PARTITION FROM command
     struct ReplaceRangeEntry
     {

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
@@ -107,10 +107,6 @@ struct ReplicatedMergeTreeLogEntryData
     /// For DROP_RANGE, true means that the parts need not be deleted, but moved to the `detached` directory.
     bool detach = false;
 
-    /// For MOVE_PART operation, task that initiated this action
-    String task_name;
-    String task_entry_zk_path;
-
     /// REPLACE PARTITION FROM command
     struct ReplaceRangeEntry
     {
@@ -176,6 +172,10 @@ struct ReplicatedMergeTreeLogEntryData
 
     /// The quorum value (for GET_PART) is a non-zero value when the quorum write is enabled.
     size_t quorum = 0;
+
+    /// For MOVE_PART operation, task that initiated this action
+    String task_name;
+    String task_entry_zk_path;
 
     /// Used only in tests for permanent fault injection for particular queue entry.
     CopyableAtomic<bool> fault_injected{false};

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3683,8 +3683,6 @@ void StorageReplicatedMergeTree::updateMovePartTask( const LogEntry & logEntry, 
     }
 }
 
-
-
 bool StorageReplicatedMergeTree::processQueueEntry(ReplicatedMergeTreeQueue::SelectedEntryPtr selected_entry)
 {
     LogEntryPtr & entry = selected_entry->log_entry;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3681,7 +3681,7 @@ void StorageReplicatedMergeTree::updateMovePartTask(const LogEntry & logEntry, b
             /// Node was updated meanwhile. We must re-read it and repeat all the actions.
             continue;
         }
-        else 
+        else
         {
             throw Coordination::Exception::fromPath(code, fs::path(logEntry.task_entry_zk_path) / "tasks" / logEntry.task_name);
         }

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3652,11 +3652,13 @@ void StorageReplicatedMergeTree::updateMovePartTask(const LogEntry & logEntry, b
     auto zookeeper = getZooKeeper();
     String value;
     Coordination::Stat stat;
-    if (!result){
+    if (!result)
+    {
         LOG_DEBUG(log, "Task {} failed to execute {} on replica {} ", logEntry.task_name, logEntry.typeToString(), replica_name);
         return;
     }
-    while (zookeeper->tryGet(fs::path(logEntry.task_entry_zk_path) / "tasks" / logEntry.task_name, value, &stat)){
+    while (zookeeper->tryGet(fs::path(logEntry.task_entry_zk_path) / "tasks" / logEntry.task_name, value, &stat))
+    {
         PartMovesBetweenShardsOrchestrator::Entry entry;
         entry.fromString(value);
         entry.replicas.push_back(replica_name);
@@ -3664,7 +3666,8 @@ void StorageReplicatedMergeTree::updateMovePartTask(const LogEntry & logEntry, b
         Coordination::Requests ops;
         Coordination::Responses responses;
         ops.emplace_back(zkutil::makeSetRequest(fs::path(logEntry.task_entry_zk_path) / "tasks" / logEntry.task_name, entry.toString(), stat.version));
-        if (entry.replicas.size() == entry.required_number_of_replicas){
+        if (entry.replicas.size() == entry.required_number_of_replicas)
+        {
             ops.emplace_back(zkutil::makeCreateRequest(fs::path(logEntry.task_entry_zk_path) / "task_queue" / logEntry.task_name, replica_name, zkutil::CreateMode::Persistent, true));
         }
 
@@ -3678,7 +3681,8 @@ void StorageReplicatedMergeTree::updateMovePartTask(const LogEntry & logEntry, b
             /// Node was updated meanwhile. We must re-read it and repeat all the actions.
             continue;
         }
-        else {
+        else 
+        {
             throw Coordination::Exception::fromPath(code, fs::path(logEntry.task_entry_zk_path) / "tasks" / logEntry.task_name);
         }
     }
@@ -3692,7 +3696,8 @@ bool StorageReplicatedMergeTree::processQueueEntry(ReplicatedMergeTreeQueue::Sel
         try
         {
             bool result =  executeLogEntry(*entry_to_process);
-            if (!entry_to_process->task_name.empty()){
+            if (!entry_to_process->task_name.empty())
+            {
                 updateMovePartTask(*entry_to_process, result);
             }
             return result;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3656,7 +3656,6 @@ void StorageReplicatedMergeTree::updateMovePartTask( const LogEntry & logEntry, 
         LOG_DEBUG(log, "Task {} failed to execute {} on replica {} ", logEntry.task_name, logEntry.typeToString(), replica_name);
         return;
     }
-    
     while(zookeeper->tryGet(fs::path(logEntry.task_entry_zk_path) / "tasks" / logEntry.task_name, value, &stat)){
         PartMovesBetweenShardsOrchestrator::Entry entry;
         entry.fromString(value);
@@ -8710,7 +8709,6 @@ void StorageReplicatedMergeTree::movePartitionToShard(
     part_move_entry.part_name = part->name;
     part_move_entry.part_uuid = part->uuid;
     part_move_entry.to_shard = to;
-
     String task_name = "task-"+ toString(part_move_entry.task_uuid);
 
     Coordination::Requests ops;
@@ -8719,14 +8717,12 @@ void StorageReplicatedMergeTree::movePartitionToShard(
     ops.emplace_back(zkutil::makeSetRequest(to + "/pinned_part_uuids", dst_pins.toString(), dst_pins.stat.version));
     ops.emplace_back(zkutil::makeCreateRequest( fs::path(part_moves_between_shards_orchestrator.entries_znode_path) / "tasks" / task_name, part_move_entry.toString(), zkutil::CreateMode::Persistent));
     ops.emplace_back(zkutil::makeCreateRequest( fs::path(part_moves_between_shards_orchestrator.entries_znode_path) / "task_queue" / task_name, "", zkutil::CreateMode::Persistent));
-
     Coordination::Responses responses;
     Coordination::Error rc = zookeeper->tryMulti(ops, responses);
     zkutil::KeeperMultiException::check(rc, ops, responses);
 
     String task_znode_path = dynamic_cast<const Coordination::CreateResponse &>(*responses.back()).path_created;
     LOG_DEBUG(log, "Created task for part movement between shards at {}", task_znode_path);
-
     /// TODO(nv): Nice to have support for `alter_sync`.
     ///     For now use the system.part_moves_between_shards table for status.
 }

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1787,7 +1787,6 @@ void StorageReplicatedMergeTree::syncPinnedPartUUIDs(bool startup)
         auto new_pinned_part_uuids = std::make_shared<PinnedPartUUIDs>();
         new_pinned_part_uuids->fromString(s);
         new_pinned_part_uuids->stat = stat;
-        
         /// No queries could be run in parallel with pinned_part_uuids
         /// updating, otherwise that query could be started without
         /// pinned_part_uuids, then it will receive some UUIds from remote
@@ -3658,22 +3657,19 @@ void StorageReplicatedMergeTree::updateMovePartTask( const LogEntry & logEntry, 
         return;
     }
     
-    while (zookeeper->tryGet(fs::path(logEntry.task_entry_zk_path) / "tasks" / logEntry.task_name, value, &stat)){
+    while(zookeeper->tryGet(fs::path(logEntry.task_entry_zk_path) / "tasks" / logEntry.task_name, value, &stat)){
         PartMovesBetweenShardsOrchestrator::Entry entry;
         entry.fromString(value);
         entry.replicas.push_back(replica_name);
 
         Coordination::Requests ops;
         Coordination::Responses responses;
-
         ops.emplace_back(zkutil::makeSetRequest(fs::path(logEntry.task_entry_zk_path) / "tasks" / logEntry.task_name, entry.toString(), stat.version));
-
         if(entry.replicas.size() == entry.required_number_of_replicas){
             ops.emplace_back(zkutil::makeCreateRequest(fs::path(logEntry.task_entry_zk_path) / "task_queue" / logEntry.task_name, replica_name, zkutil::CreateMode::Persistent, true));
         }
 
         auto code = zookeeper->tryMulti(ops, responses);
-
         if (code == Coordination::Error::ZOK || code == Coordination::Error::ZNODEEXISTS)
         {
             break;
@@ -3685,9 +3681,7 @@ void StorageReplicatedMergeTree::updateMovePartTask( const LogEntry & logEntry, 
         } else {
             throw Coordination::Exception::fromPath(code, fs::path(logEntry.task_entry_zk_path) / "tasks" / logEntry.task_name);
         }
-
     }
-
 }
 
 
@@ -8723,7 +8717,6 @@ void StorageReplicatedMergeTree::movePartitionToShard(
     ops.emplace_back(zkutil::makeCheckRequest(zookeeper_path + "/log", merge_pred.getVersion())); /// Make sure no new events were added to the log.
     ops.emplace_back(zkutil::makeSetRequest(zookeeper_path + "/pinned_part_uuids", src_pins.toString(), src_pins.stat.version));
     ops.emplace_back(zkutil::makeSetRequest(to + "/pinned_part_uuids", dst_pins.toString(), dst_pins.stat.version));
-
     ops.emplace_back(zkutil::makeCreateRequest( fs::path(part_moves_between_shards_orchestrator.entries_znode_path) / "tasks" / task_name, part_move_entry.toString(), zkutil::CreateMode::Persistent));
     ops.emplace_back(zkutil::makeCreateRequest( fs::path(part_moves_between_shards_orchestrator.entries_znode_path) / "task_queue" / task_name, "", zkutil::CreateMode::Persistent));
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3658,7 +3658,7 @@ void StorageReplicatedMergeTree::updateMovePartTask( const LogEntry & logEntry, 
         return;
     }
     
-    while (zookeeper->tryGet(fs::path(logEntry.task_entry_zk_path) / "tasks" / logEntry.task_name , value, &stat)){
+    while (zookeeper->tryGet(fs::path(logEntry.task_entry_zk_path) / "tasks" / logEntry.task_name, value, &stat)){
         PartMovesBetweenShardsOrchestrator::Entry entry;
         entry.fromString(value);
         entry.replicas.push_back(replica_name);

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -655,7 +655,7 @@ private:
     /// Removes a part from ZooKeeper and adds a task to the queue to download it. It is supposed to do this with broken parts.
     void removePartAndEnqueueFetch(const String & part_name, bool storage_init);
 
-    /// Update the move_part task result in the queue checks for the quorum 
+    /// Update the move_part task result in the queue checks for the quorum
     void updateMovePartTask(const LogEntry & entry, bool result);
 
     /// Running jobs from the queue.

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -606,7 +606,7 @@ private:
 
     /// Synchronize the list of part uuids which are currently pinned. These should be sent to root query executor
     /// to be used for deduplication.
-    void syncPinnedPartUUIDs();
+    void syncPinnedPartUUIDs(bool startup);
 
     /** Check that the part's checksum is the same as the checksum of the same part on some other replica.
       * If no one has such a part, nothing checks.
@@ -654,6 +654,9 @@ private:
 
     /// Removes a part from ZooKeeper and adds a task to the queue to download it. It is supposed to do this with broken parts.
     void removePartAndEnqueueFetch(const String & part_name, bool storage_init);
+
+    /// Update the move_part task result in the queue checks for the quorum 
+    void updateMovePartTask(const LogEntry & entry, bool result);
 
     /// Running jobs from the queue.
 

--- a/tests/integration/test_part_moves_between_shards/configs/merge_tree.xml
+++ b/tests/integration/test_part_moves_between_shards/configs/merge_tree.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <merge_tree>
+        <assign_part_uuids>1</assign_part_uuids>
+        <part_moves_between_shards_enable>1</part_moves_between_shards_enable>
+    </merge_tree>
+</clickhouse>

--- a/tests/integration/test_part_moves_between_shards/configs/merge_tree.xml
+++ b/tests/integration/test_part_moves_between_shards/configs/merge_tree.xml
@@ -2,5 +2,6 @@
     <merge_tree>
         <assign_part_uuids>1</assign_part_uuids>
         <part_moves_between_shards_enable>1</part_moves_between_shards_enable>
+        <disable_quorum_check_move_parts>1</disable_quorum_check_move_parts>
     </merge_tree>
 </clickhouse>

--- a/tests/integration/test_part_moves_between_shards/configs/merge_tree.xml
+++ b/tests/integration/test_part_moves_between_shards/configs/merge_tree.xml
@@ -2,6 +2,5 @@
     <merge_tree>
         <assign_part_uuids>1</assign_part_uuids>
         <part_moves_between_shards_enable>1</part_moves_between_shards_enable>
-        <disable_quorum_check_move_parts>1</disable_quorum_check_move_parts>
     </merge_tree>
 </clickhouse>

--- a/tests/integration/test_part_moves_between_shards/configs/remote_servers.xml
+++ b/tests/integration/test_part_moves_between_shards/configs/remote_servers.xml
@@ -1,0 +1,26 @@
+<clickhouse>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>s0r0</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>s0r1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+            <shard>
+                <replica>
+                    <host>s1r0</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>s1r1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_part_moves_between_shards/test.py
+++ b/tests/integration/test_part_moves_between_shards/test.py
@@ -1,0 +1,647 @@
+import pytest
+import random
+import threading
+import time
+
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
+
+transient_ch_errors = [23, 32, 210]
+
+cluster = ClickHouseCluster(__file__)
+
+s0r0 = cluster.add_instance(
+    "s0r0",
+    main_configs=["configs/remote_servers.xml", "configs/merge_tree.xml"],
+    stay_alive=True,
+    with_zookeeper=True,
+)
+
+s0r1 = cluster.add_instance(
+    "s0r1",
+    main_configs=["configs/remote_servers.xml", "configs/merge_tree.xml"],
+    stay_alive=True,
+    with_zookeeper=True,
+)
+
+s1r0 = cluster.add_instance(
+    "s1r0",
+    main_configs=["configs/remote_servers.xml", "configs/merge_tree.xml"],
+    stay_alive=True,
+    with_zookeeper=True,
+)
+
+s1r1 = cluster.add_instance(
+    "s1r1",
+    main_configs=["configs/remote_servers.xml", "configs/merge_tree.xml"],
+    stay_alive=True,
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_move(started_cluster):
+    for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
+        for replica_ix, r in enumerate(rs):
+            r.query(
+                """
+            DROP TABLE IF EXISTS test_move;
+            CREATE TABLE test_move(v UInt64)
+            ENGINE ReplicatedMergeTree('/clickhouse/shard_{}/tables/test_move', '{}')
+            ORDER BY tuple()
+            """.format(
+                    shard_ix, r.name
+                )
+            )
+
+    s0r0.query("SYSTEM STOP MERGES test_move")
+    s0r1.query("SYSTEM STOP MERGES test_move")
+
+    s0r0.query("INSERT INTO test_move VALUES (1)")
+    s0r0.query("INSERT INTO test_move VALUES (2)")
+
+    assert "2" == s0r0.query("SELECT count() FROM test_move").strip()
+    assert "0" == s1r0.query("SELECT count() FROM test_move").strip()
+
+    s0r0.query(
+        "ALTER TABLE test_move MOVE PART 'all_0_0_0' TO SHARD '/clickhouse/shard_1/tables/test_move'"
+    )
+
+    print(s0r0.query("SELECT * FROM system.part_moves_between_shards"))
+
+    s0r0.query("SYSTEM START MERGES test_move")
+    s0r0.query("OPTIMIZE TABLE test_move FINAL")
+
+    wait_for_state("DONE", s0r0, "test_move")
+
+    for n in [s0r0, s0r1]:
+        assert "1" == n.query("SELECT count() FROM test_move").strip()
+
+    for n in [s1r0, s1r1]:
+        assert "1" == n.query("SELECT count() FROM test_move").strip()
+
+    # Move part back
+    s1r0.query(
+        "ALTER TABLE test_move MOVE PART 'all_0_0_0' TO SHARD '/clickhouse/shard_0/tables/test_move'"
+    )
+
+    wait_for_state("DONE", s1r0, "test_move")
+
+    for n in [s0r0, s0r1]:
+        assert "2" == n.query("SELECT count() FROM test_move").strip()
+
+    for n in [s1r0, s1r1]:
+        assert "0" == n.query("SELECT count() FROM test_move").strip()
+
+
+def test_deduplication_while_move(started_cluster):
+    for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
+        for replica_ix, r in enumerate(rs):
+            r.query(
+                """
+            DROP TABLE IF EXISTS test_deduplication;
+            CREATE TABLE test_deduplication(v UInt64)
+            ENGINE ReplicatedMergeTree('/clickhouse/shard_{}/tables/test_deduplication', '{}')
+            ORDER BY tuple()
+            """.format(
+                    shard_ix, r.name
+                )
+            )
+
+            r.query(
+                """
+            DROP TABLE IF EXISTS test_deduplication_d;
+            CREATE TABLE test_deduplication_d AS test_deduplication
+            ENGINE Distributed('test_cluster', '', test_deduplication)
+            """
+            )
+
+    s0r0.query("SYSTEM STOP MERGES test_deduplication")
+    s0r1.query("SYSTEM STOP MERGES test_deduplication")
+
+    s0r0.query("INSERT INTO test_deduplication VALUES (1)")
+    s0r0.query("INSERT INTO test_deduplication VALUES (2)")
+    s0r1.query("SYSTEM SYNC REPLICA test_deduplication", timeout=20)
+
+    assert "2" == s0r0.query("SELECT count() FROM test_deduplication").strip()
+    assert "0" == s1r0.query("SELECT count() FROM test_deduplication").strip()
+
+    s0r0.query(
+        "ALTER TABLE test_deduplication MOVE PART 'all_0_0_0' TO SHARD '/clickhouse/shard_1/tables/test_deduplication'"
+    )
+    s0r0.query("SYSTEM START MERGES test_deduplication")
+
+    expected = """
+1
+2
+"""
+
+    def deduplication_invariant_test():
+        n = random.choice(list(started_cluster.instances.values()))
+        assert TSV(
+            n.query(
+                "SELECT * FROM test_deduplication_d ORDER BY v",
+                settings={"allow_experimental_query_deduplication": 1},
+            )
+        ) == TSV(expected)
+
+        # https://github.com/ClickHouse/ClickHouse/issues/34089
+        assert TSV(
+            n.query(
+                "SELECT count() FROM test_deduplication_d",
+                settings={"allow_experimental_query_deduplication": 1},
+            )
+        ) == TSV("2")
+
+        assert TSV(
+            n.query(
+                "SELECT count() FROM test_deduplication_d",
+                settings={"allow_experimental_query_deduplication": 1},
+            )
+        ) == TSV("2")
+
+    deduplication_invariant = ConcurrentInvariant(deduplication_invariant_test)
+    deduplication_invariant.start()
+
+    wait_for_state("DONE", s0r0, "test_deduplication")
+
+    deduplication_invariant.stop_and_assert_no_exception()
+
+
+def test_part_move_step_by_step(started_cluster):
+    for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
+        for replica_ix, r in enumerate(rs):
+            r.query(
+                """
+            DROP TABLE IF EXISTS test_part_move_step_by_step;
+            CREATE TABLE test_part_move_step_by_step(v UInt64)
+            ENGINE ReplicatedMergeTree('/clickhouse/shard_{}/tables/test_part_move_step_by_step', '{}')
+            ORDER BY tuple()
+            """.format(
+                    shard_ix, r.name
+                )
+            )
+
+            r.query(
+                """
+            DROP TABLE IF EXISTS test_part_move_step_by_step_d;
+            CREATE TABLE test_part_move_step_by_step_d AS test_part_move_step_by_step
+            ENGINE Distributed('test_cluster', currentDatabase(), test_part_move_step_by_step)
+            """
+            )
+
+    s0r0.query("SYSTEM STOP MERGES test_part_move_step_by_step")
+    s0r1.query("SYSTEM STOP MERGES test_part_move_step_by_step")
+
+    s0r0.query("INSERT INTO test_part_move_step_by_step VALUES (1)")
+    s0r0.query("INSERT INTO test_part_move_step_by_step VALUES (2)")
+    s0r1.query("SYSTEM SYNC REPLICA test_part_move_step_by_step", timeout=20)
+
+    assert "2" == s0r0.query("SELECT count() FROM test_part_move_step_by_step").strip()
+    assert "0" == s1r0.query("SELECT count() FROM test_part_move_step_by_step").strip()
+
+    expected = """
+1
+2
+"""
+
+    def deduplication_invariant_test():
+        n = random.choice(list(started_cluster.instances.values()))
+        try:
+            assert TSV(
+                n.query(
+                    "SELECT * FROM test_part_move_step_by_step_d ORDER BY v",
+                    settings={"allow_experimental_query_deduplication": 1},
+                )
+            ) == TSV(expected)
+        except QueryRuntimeException as e:
+            # ignore transient errors that are caused by us restarting nodes
+            if e.returncode not in transient_ch_errors:
+                raise e
+
+    deduplication_invariant = ConcurrentInvariant(deduplication_invariant_test)
+    deduplication_invariant.start()
+
+    # Stop a source replica to prevent SYNC_SOURCE succeeding.
+    s0r1.stop_clickhouse()
+
+    s0r0.query(
+        "ALTER TABLE test_part_move_step_by_step MOVE PART 'all_0_0_0' TO SHARD '/clickhouse/shard_1/tables/test_part_move_step_by_step'"
+    )
+
+    # Should hang on SYNC_SOURCE until all source replicas acknowledge new pinned UUIDs.
+    wait_for_state(
+        "SYNC_SOURCE",
+        s0r0,
+        "test_part_move_step_by_step",
+        "Some replicas haven\\'t processed event",
+    )
+    deduplication_invariant.assert_no_exception()
+
+    # Start all replicas in source shard but stop a replica in destination shard
+    # to prevent SYNC_DESTINATION succeeding.
+    s1r1.stop_clickhouse()
+    s0r1.start_clickhouse()
+
+    # After SYNC_SOURCE step no merges will be assigned.
+    s0r0.query(
+        "SYSTEM START MERGES test_part_move_step_by_step; OPTIMIZE TABLE test_part_move_step_by_step;"
+    )
+    s0r1.query(
+        "SYSTEM START MERGES test_part_move_step_by_step; OPTIMIZE TABLE test_part_move_step_by_step;"
+    )
+
+    wait_for_state(
+        "SYNC_DESTINATION",
+        s0r0,
+        "test_part_move_step_by_step",
+        "Some replicas haven\\'t processed event",
+    )
+    deduplication_invariant.assert_no_exception()
+
+    # Start previously stopped replica in destination shard to let SYNC_DESTINATION
+    # succeed.
+    # Stop the other replica in destination shard to prevent DESTINATION_FETCH succeed.
+    s1r0.stop_clickhouse()
+    s1r1.start_clickhouse()
+    wait_for_state(
+        "DESTINATION_FETCH",
+        s0r0,
+        "test_part_move_step_by_step",
+        "Some replicas haven\\'t processed event",
+    )
+    deduplication_invariant.assert_no_exception()
+
+    # Start previously stopped replica in destination shard to let DESTINATION_FETCH
+    # succeed.
+    # Stop the other replica in destination shard to prevent DESTINATION_ATTACH succeed.
+    s1r1.stop_clickhouse()
+    s1r0.start_clickhouse()
+    wait_for_state(
+        "DESTINATION_ATTACH",
+        s0r0,
+        "test_part_move_step_by_step",
+        "Some replicas haven\\'t processed event",
+    )
+    deduplication_invariant.assert_no_exception()
+
+    # Start all replicas in destination shard to let DESTINATION_ATTACH succeed.
+    # Stop a source replica to prevent SOURCE_DROP succeeding.
+    s0r0.stop_clickhouse()
+    s1r1.start_clickhouse()
+    wait_for_state(
+        "SOURCE_DROP",
+        s0r1,
+        "test_part_move_step_by_step",
+        "Some replicas haven\\'t processed event",
+    )
+    deduplication_invariant.assert_no_exception()
+
+    s0r0.start_clickhouse()
+    wait_for_state("DONE", s0r1, "test_part_move_step_by_step")
+    deduplication_invariant.assert_no_exception()
+
+    # No hung tasks in replication queue. Would timeout otherwise.
+    for instance in started_cluster.instances.values():
+        instance.query("SYSTEM SYNC REPLICA test_part_move_step_by_step")
+
+    assert "1" == s0r0.query("SELECT count() FROM test_part_move_step_by_step").strip()
+    assert "1" == s1r0.query("SELECT count() FROM test_part_move_step_by_step").strip()
+
+    deduplication_invariant.stop_and_assert_no_exception()
+
+
+def test_part_move_step_by_step_kill(started_cluster):
+    for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
+        for replica_ix, r in enumerate(rs):
+            r.query(
+                """
+            DROP TABLE IF EXISTS test_part_move_step_by_step_kill;
+            CREATE TABLE test_part_move_step_by_step_kill(v UInt64)
+            ENGINE ReplicatedMergeTree('/clickhouse/shard_{}/tables/test_part_move_step_by_step_kill', '{}')
+            ORDER BY tuple()
+            """.format(
+                    shard_ix, r.name
+                )
+            )
+
+            r.query(
+                """
+            DROP TABLE IF EXISTS test_part_move_step_by_step_kill_d;
+            CREATE TABLE test_part_move_step_by_step_kill_d AS test_part_move_step_by_step_kill
+            ENGINE Distributed('test_cluster', currentDatabase(), test_part_move_step_by_step_kill)
+            """
+            )
+
+    s0r0.query("SYSTEM STOP MERGES test_part_move_step_by_step_kill")
+    s0r1.query("SYSTEM STOP MERGES test_part_move_step_by_step_kill")
+
+    s0r0.query("INSERT INTO test_part_move_step_by_step_kill VALUES (1)")
+    s0r0.query("INSERT INTO test_part_move_step_by_step_kill VALUES (2)")
+    s0r1.query("SYSTEM SYNC REPLICA test_part_move_step_by_step_kill", timeout=20)
+
+    assert (
+        "2"
+        == s0r0.query("SELECT count() FROM test_part_move_step_by_step_kill").strip()
+    )
+    assert (
+        "0"
+        == s1r0.query("SELECT count() FROM test_part_move_step_by_step_kill").strip()
+    )
+
+    expected = """
+1
+2
+"""
+
+    def deduplication_invariant_test():
+        n = random.choice(list(started_cluster.instances.values()))
+        try:
+            assert TSV(
+                n.query(
+                    "SELECT * FROM test_part_move_step_by_step_kill_d ORDER BY v",
+                    settings={"allow_experimental_query_deduplication": 1},
+                )
+            ) == TSV(expected)
+        except QueryRuntimeException as e:
+            # ignore transient errors that are caused by us restarting nodes
+            if e.returncode not in transient_ch_errors:
+                raise e
+
+    deduplication_invariant = ConcurrentInvariant(deduplication_invariant_test)
+    deduplication_invariant.start()
+
+    # Stop a source replica to prevent SYNC_SOURCE succeeding.
+    s0r1.stop_clickhouse()
+
+    s0r0.query(
+        "ALTER TABLE test_part_move_step_by_step_kill MOVE PART 'all_0_0_0' TO SHARD '/clickhouse/shard_1/tables/test_part_move_step_by_step_kill'"
+    )
+
+    # Should hang on SYNC_SOURCE until all source replicas acknowledge new pinned UUIDs.
+    wait_for_state(
+        "SYNC_SOURCE",
+        s0r0,
+        "test_part_move_step_by_step_kill",
+        "Some replicas haven\\'t processed event",
+    )
+    deduplication_invariant.assert_no_exception()
+
+    # Start all replicas in source shard but stop a replica in destination shard
+    # to prevent SYNC_DESTINATION succeeding.
+    s1r1.stop_clickhouse()
+    s0r1.start_clickhouse()
+
+    # After SYNC_SOURCE step no merges will be assigned.
+    s0r0.query(
+        "SYSTEM START MERGES test_part_move_step_by_step_kill; OPTIMIZE TABLE test_part_move_step_by_step_kill;"
+    )
+    s0r1.query(
+        "SYSTEM START MERGES test_part_move_step_by_step_kill; OPTIMIZE TABLE test_part_move_step_by_step_kill;"
+    )
+
+    wait_for_state(
+        "SYNC_DESTINATION",
+        s0r0,
+        "test_part_move_step_by_step_kill",
+        "Some replicas haven\\'t processed event",
+    )
+    deduplication_invariant.assert_no_exception()
+
+    # Start previously stopped replica in destination shard to let SYNC_DESTINATION
+    # succeed.
+    # Stop the other replica in destination shard to prevent DESTINATION_FETCH succeed.
+    s1r0.stop_clickhouse()
+    s1r1.start_clickhouse()
+    wait_for_state(
+        "DESTINATION_FETCH",
+        s0r0,
+        "test_part_move_step_by_step_kill",
+        "Some replicas haven\\'t processed event",
+    )
+
+    # Start previously stopped replica in destination shard to let DESTINATION_FETCH
+    # succeed.
+    # Stop the other replica in destination shard to prevent DESTINATION_ATTACH succeed.
+    s1r1.stop_clickhouse()
+    s1r0.start_clickhouse()
+    wait_for_state(
+        "DESTINATION_ATTACH",
+        s0r0,
+        "test_part_move_step_by_step_kill",
+        "Some replicas haven\\'t processed event",
+    )
+    deduplication_invariant.assert_no_exception()
+
+    # Rollback here.
+    s0r0.query(
+        """
+        KILL PART_MOVE_TO_SHARD
+        WHERE task_uuid = (SELECT task_uuid FROM system.part_moves_between_shards WHERE table = 'test_part_move_step_by_step_kill')
+    """
+    )
+
+    wait_for_state(
+        "DESTINATION_ATTACH",
+        s0r0,
+        "test_part_move_step_by_step_kill",
+        assert_exception_msg="Some replicas haven\\'t processed event",
+        assert_rollback=True,
+    )
+
+    s1r1.start_clickhouse()
+
+    wait_for_state(
+        "CANCELLED", s0r0, "test_part_move_step_by_step_kill", assert_rollback=True
+    )
+    deduplication_invariant.assert_no_exception()
+
+    # No hung tasks in replication queue. Would timeout otherwise.
+    for instance in started_cluster.instances.values():
+        instance.query("SYSTEM SYNC REPLICA test_part_move_step_by_step_kill")
+
+    assert (
+        "2"
+        == s0r0.query("SELECT count() FROM test_part_move_step_by_step_kill").strip()
+    )
+    assert (
+        "0"
+        == s1r0.query("SELECT count() FROM test_part_move_step_by_step_kill").strip()
+    )
+
+    deduplication_invariant.stop_and_assert_no_exception()
+
+
+def test_move_not_permitted(started_cluster):
+    # Verify that invariants for part compatibility are checked.
+
+    # Tests are executed in order. Make sure cluster is up if previous test
+    # failed.
+    s0r0.start_clickhouse()
+    s1r0.start_clickhouse()
+
+    for ix, n in enumerate([s0r0, s1r0]):
+        n.query(
+            """
+        DROP TABLE IF EXISTS not_permitted_columns;
+        
+        CREATE TABLE not_permitted_columns(v_{ix} UInt64)
+        ENGINE ReplicatedMergeTree('/clickhouse/shard_{ix}/tables/not_permitted_columns', 'r')
+        ORDER BY tuple();
+        """.format(
+                ix=ix
+            )
+        )
+
+        partition = "date"
+        if ix > 0:
+            partition = "v"
+
+        n.query(
+            """
+        DROP TABLE IF EXISTS not_permitted_partition;
+        CREATE TABLE not_permitted_partition(date Date, v UInt64)
+        ENGINE ReplicatedMergeTree('/clickhouse/shard_{ix}/tables/not_permitted_partition', 'r')
+        PARTITION BY ({partition})
+        ORDER BY tuple();
+        """.format(
+                ix=ix, partition=partition
+            )
+        )
+
+    s0r0.query("INSERT INTO not_permitted_columns VALUES (1)")
+    s0r0.query("INSERT INTO not_permitted_partition VALUES ('2021-09-03', 1)")
+
+    with pytest.raises(
+        QueryRuntimeException,
+        match="DB::Exception: Source and destination are the same",
+    ):
+        s0r0.query(
+            "ALTER TABLE not_permitted_columns MOVE PART 'all_0_0_0' TO SHARD '/clickhouse/shard_0/tables/not_permitted_columns'"
+        )
+
+    with pytest.raises(
+        QueryRuntimeException,
+        match="DB::Exception: Table columns structure in ZooKeeper is different from local table structure.",
+    ):
+        s0r0.query(
+            "ALTER TABLE not_permitted_columns MOVE PART 'all_0_0_0' TO SHARD '/clickhouse/shard_1/tables/not_permitted_columns'"
+        )
+
+    with pytest.raises(
+        QueryRuntimeException,
+        match="DB::Exception: Existing table metadata in ZooKeeper differs in partition key expression.",
+    ):
+        s0r0.query(
+            "ALTER TABLE not_permitted_partition MOVE PART '20210903_0_0_0' TO SHARD '/clickhouse/shard_1/tables/not_permitted_partition'"
+        )
+
+
+def wait_for_state(
+    desired_state,
+    instance,
+    test_table,
+    assert_exception_msg=None,
+    assert_rollback=False,
+):
+    last_debug_print_time = time.time()
+
+    print("Waiting to reach state: {}".format(desired_state))
+    if assert_exception_msg:
+        print("  with exception contents: {}".format(assert_exception_msg))
+    if assert_rollback:
+        print("     and rollback: {}".format(assert_rollback))
+
+    while True:
+        tasks = TSV.toMat(
+            instance.query(
+                "SELECT state, num_tries, last_exception, rollback FROM system.part_moves_between_shards WHERE table = '{}'".format(
+                    test_table
+                )
+            )
+        )
+        assert len(tasks) == 1, "only one task expected in this test"
+
+        if time.time() - last_debug_print_time > 30:
+            last_debug_print_time = time.time()
+            print("Current state: ", tasks)
+
+        [state, num_tries, last_exception, rollback] = tasks[0]
+
+        if state == desired_state:
+            if assert_exception_msg and int(num_tries) < 3:
+                # Let the task be retried a few times when expecting an exception
+                # to make sure the exception is persistent and the code doesn't
+                # accidentally continue to run when we expect it not to.
+                continue
+
+            if assert_exception_msg:
+                assert assert_exception_msg in last_exception
+
+            if assert_rollback:
+                assert int(rollback) == 1, "rollback bit isn't set"
+
+            break
+        elif state in ["DONE", "CANCELLED"]:
+            raise Exception(
+                "Reached terminal state {}, but was waiting for {}".format(
+                    state, desired_state
+                )
+            )
+
+        time.sleep(0.1)
+
+
+class ConcurrentInvariant:
+    def __init__(self, invariant_test, loop_sleep=0.1):
+        self.invariant_test = invariant_test
+        self.loop_sleep = loop_sleep
+
+        self.started = False
+        self.exiting = False
+        self.exception = None
+        self.thread = threading.Thread(target=self._loop)
+
+    def start(self):
+        if self.started:
+            raise Exception("invariant thread already started")
+
+        self.started = True
+        self.thread.start()
+
+    def stop_and_assert_no_exception(self):
+        self._assert_started()
+
+        self.exiting = True
+        self.thread.join()
+
+        if self.exception:
+            raise self.exception
+
+    def assert_no_exception(self):
+        self._assert_started()
+
+        if self.exception:
+            raise self.exception
+
+    def _loop(self):
+        try:
+            while not self.exiting:
+                self.invariant_test()
+                time.sleep(self.loop_sleep)
+        except Exception as e:
+            self.exiting = True
+            self.exception = e
+
+    def _assert_started(self):
+        if not self.started:
+            raise Exception("invariant thread not started, forgot to call start?")

--- a/tests/integration/test_part_moves_between_shards/test.py
+++ b/tests/integration/test_part_moves_between_shards/test.py
@@ -599,4 +599,3 @@ class ConcurrentInvariant:
     def _assert_started(self):
         if not self.started:
             raise Exception("invariant thread not started, forgot to call start?")
-        

--- a/tests/integration/test_part_moves_between_shards/test.py
+++ b/tests/integration/test_part_moves_between_shards/test.py
@@ -379,7 +379,7 @@ def test_part_move_step_by_step_kill(started_cluster):
         "SYSTEM START MERGES test_part_move_step_by_step_kill; OPTIMIZE TABLE test_part_move_step_by_step_kill;"
     )
 
-    wait_for_state("SYNC_DESTINATION", s0r0, "test_part_move_step_by_step_kill" )
+    wait_for_state("SYNC_DESTINATION", s0r0, "test_part_move_step_by_step_kill")
     deduplication_invariant.assert_no_exception()
 
     # Start previously stopped replica in destination shard to let SYNC_DESTINATION
@@ -405,11 +405,18 @@ def test_part_move_step_by_step_kill(started_cluster):
     """
     )
 
-    wait_for_state("DESTINATION_ATTACH", s0r0, "test_part_move_step_by_step_kill", assert_rollback=True)
+    wait_for_state(
+        "DESTINATION_ATTACH",
+        s0r0,
+        "test_part_move_step_by_step_kill",
+        assert_rollback=True,
+    )
 
     s1r1.start_clickhouse()
 
-    wait_for_state("CANCELLED", s0r0, "test_part_move_step_by_step_kill", assert_rollback=True)
+    wait_for_state(
+        "CANCELLED", s0r0, "test_part_move_step_by_step_kill", assert_rollback=True
+    )
     deduplication_invariant.assert_no_exception()
 
     # No hung tasks in replication queue. Would timeout otherwise.

--- a/tests/integration/test_part_moves_between_shards/test.py
+++ b/tests/integration/test_part_moves_between_shards/test.py
@@ -106,6 +106,7 @@ def test_move(started_cluster):
         for replica_ix, r in enumerate(rs):
             r.query("DROP TABLE test_move SYNC")
 
+
 def test_deduplication_while_move(started_cluster):
     for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
         for replica_ix, r in enumerate(rs):
@@ -182,6 +183,7 @@ def test_deduplication_while_move(started_cluster):
     for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
         for replica_ix, r in enumerate(rs):
             r.query("DROP TABLE test_deduplication SYNC")
+
 
 def test_part_move_step_by_step(started_cluster):
     for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
@@ -303,6 +305,7 @@ def test_part_move_step_by_step(started_cluster):
     for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
         for replica_ix, r in enumerate(rs):
             r.query("DROP TABLE test_part_move_step_by_step SYNC")
+
 
 def test_part_move_step_by_step_kill(started_cluster):
     for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
@@ -511,6 +514,7 @@ def test_move_not_permitted(started_cluster):
         s0r0.query(
             "ALTER TABLE not_permitted_partition MOVE PART '20210903_0_0_0' TO SHARD '/clickhouse/shard_1/tables/not_permitted_partition'"
         )
+
 
 def wait_for_state(
     desired_state,

--- a/tests/integration/test_part_moves_between_shards/test.py
+++ b/tests/integration/test_part_moves_between_shards/test.py
@@ -242,9 +242,7 @@ def test_part_move_step_by_step(started_cluster):
     wait_for_state(
         "SYNC_SOURCE",
         s0r0,
-        "test_part_move_step_by_step",
-        "Some replicas haven\\'t processed event",
-    )
+        "test_part_move_step_by_step")
     deduplication_invariant.assert_no_exception()
 
     # Start all replicas in source shard but stop a replica in destination shard
@@ -263,9 +261,7 @@ def test_part_move_step_by_step(started_cluster):
     wait_for_state(
         "SYNC_DESTINATION",
         s0r0,
-        "test_part_move_step_by_step",
-        "Some replicas haven\\'t processed event",
-    )
+        "test_part_move_step_by_step")
     deduplication_invariant.assert_no_exception()
 
     # Start previously stopped replica in destination shard to let SYNC_DESTINATION
@@ -276,9 +272,7 @@ def test_part_move_step_by_step(started_cluster):
     wait_for_state(
         "DESTINATION_FETCH",
         s0r0,
-        "test_part_move_step_by_step",
-        "Some replicas haven\\'t processed event",
-    )
+        "test_part_move_step_by_step")
     deduplication_invariant.assert_no_exception()
 
     # Start previously stopped replica in destination shard to let DESTINATION_FETCH
@@ -289,9 +283,7 @@ def test_part_move_step_by_step(started_cluster):
     wait_for_state(
         "DESTINATION_ATTACH",
         s0r0,
-        "test_part_move_step_by_step",
-        "Some replicas haven\\'t processed event",
-    )
+        "test_part_move_step_by_step")
     deduplication_invariant.assert_no_exception()
 
     # Start all replicas in destination shard to let DESTINATION_ATTACH succeed.
@@ -301,9 +293,7 @@ def test_part_move_step_by_step(started_cluster):
     wait_for_state(
         "SOURCE_DROP",
         s0r1,
-        "test_part_move_step_by_step",
-        "Some replicas haven\\'t processed event",
-    )
+        "test_part_move_step_by_step")
     deduplication_invariant.assert_no_exception()
 
     s0r0.start_clickhouse()
@@ -391,9 +381,7 @@ def test_part_move_step_by_step_kill(started_cluster):
     wait_for_state(
         "SYNC_SOURCE",
         s0r0,
-        "test_part_move_step_by_step_kill",
-        "Some replicas haven\\'t processed event",
-    )
+        "test_part_move_step_by_step_kill")
     deduplication_invariant.assert_no_exception()
 
     # Start all replicas in source shard but stop a replica in destination shard
@@ -412,9 +400,7 @@ def test_part_move_step_by_step_kill(started_cluster):
     wait_for_state(
         "SYNC_DESTINATION",
         s0r0,
-        "test_part_move_step_by_step_kill",
-        "Some replicas haven\\'t processed event",
-    )
+        "test_part_move_step_by_step_kill" )
     deduplication_invariant.assert_no_exception()
 
     # Start previously stopped replica in destination shard to let SYNC_DESTINATION
@@ -425,9 +411,7 @@ def test_part_move_step_by_step_kill(started_cluster):
     wait_for_state(
         "DESTINATION_FETCH",
         s0r0,
-        "test_part_move_step_by_step_kill",
-        "Some replicas haven\\'t processed event",
-    )
+        "test_part_move_step_by_step_kill")
 
     # Start previously stopped replica in destination shard to let DESTINATION_FETCH
     # succeed.
@@ -437,9 +421,7 @@ def test_part_move_step_by_step_kill(started_cluster):
     wait_for_state(
         "DESTINATION_ATTACH",
         s0r0,
-        "test_part_move_step_by_step_kill",
-        "Some replicas haven\\'t processed event",
-    )
+        "test_part_move_step_by_step_kill")
     deduplication_invariant.assert_no_exception()
 
     # Rollback here.
@@ -454,8 +436,7 @@ def test_part_move_step_by_step_kill(started_cluster):
         "DESTINATION_ATTACH",
         s0r0,
         "test_part_move_step_by_step_kill",
-        assert_exception_msg="Some replicas haven\\'t processed event",
-        assert_rollback=True,
+        assert_rollback=True
     )
 
     s1r1.start_clickhouse()

--- a/tests/integration/test_part_moves_between_shards/test.py
+++ b/tests/integration/test_part_moves_between_shards/test.py
@@ -102,6 +102,9 @@ def test_move(started_cluster):
     for n in [s1r0, s1r1]:
         assert "0" == n.query("SELECT count() FROM test_move").strip()
 
+    for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
+        for replica_ix, r in enumerate(rs):
+            r.query("DROP TABLE test_move SYNC")
 
 def test_deduplication_while_move(started_cluster):
     for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
@@ -176,6 +179,9 @@ def test_deduplication_while_move(started_cluster):
 
     deduplication_invariant.stop_and_assert_no_exception()
 
+    for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
+        for replica_ix, r in enumerate(rs):
+            r.query("DROP TABLE test_deduplication SYNC")
 
 def test_part_move_step_by_step(started_cluster):
     for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
@@ -294,6 +300,9 @@ def test_part_move_step_by_step(started_cluster):
 
     deduplication_invariant.stop_and_assert_no_exception()
 
+    for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
+        for replica_ix, r in enumerate(rs):
+            r.query("DROP TABLE test_part_move_step_by_step SYNC")
 
 def test_part_move_step_by_step_kill(started_cluster):
     for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
@@ -434,6 +443,10 @@ def test_part_move_step_by_step_kill(started_cluster):
 
     deduplication_invariant.stop_and_assert_no_exception()
 
+    for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
+        for replica_ix, r in enumerate(rs):
+            r.query("DROP TABLE test_part_move_step_by_step_kill SYNC")
+
 
 def test_move_not_permitted(started_cluster):
     # Verify that invariants for part compatibility are checked.
@@ -499,6 +512,9 @@ def test_move_not_permitted(started_cluster):
             "ALTER TABLE not_permitted_partition MOVE PART '20210903_0_0_0' TO SHARD '/clickhouse/shard_1/tables/not_permitted_partition'"
         )
 
+    for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
+        for replica_ix, r in enumerate(rs):
+            r.query("DROP TABLE not_permitted_partition SYNC")
 
 def wait_for_state(
     desired_state,

--- a/tests/integration/test_part_moves_between_shards/test.py
+++ b/tests/integration/test_part_moves_between_shards/test.py
@@ -54,7 +54,7 @@ def test_move(started_cluster):
         for replica_ix, r in enumerate(rs):
             r.query(
                 """
-            DROP TABLE IF EXISTS test_move;
+            DROP TABLE IF EXISTS test_move SYNC;
             CREATE TABLE test_move(v UInt64)
             ENGINE ReplicatedMergeTree('/clickhouse/shard_{}/tables/test_move', '{}')
             ORDER BY tuple()
@@ -108,7 +108,7 @@ def test_deduplication_while_move(started_cluster):
         for replica_ix, r in enumerate(rs):
             r.query(
                 """
-            DROP TABLE IF EXISTS test_deduplication;
+            DROP TABLE IF EXISTS test_deduplication SYNC;
             CREATE TABLE test_deduplication(v UInt64)
             ENGINE ReplicatedMergeTree('/clickhouse/shard_{}/tables/test_deduplication', '{}')
             ORDER BY tuple()
@@ -119,7 +119,7 @@ def test_deduplication_while_move(started_cluster):
 
             r.query(
                 """
-            DROP TABLE IF EXISTS test_deduplication_d;
+            DROP TABLE IF EXISTS test_deduplication_d SYNC;
             CREATE TABLE test_deduplication_d AS test_deduplication
             ENGINE Distributed('test_cluster', '', test_deduplication)
             """
@@ -182,7 +182,7 @@ def test_part_move_step_by_step(started_cluster):
         for replica_ix, r in enumerate(rs):
             r.query(
                 """
-            DROP TABLE IF EXISTS test_part_move_step_by_step;
+            DROP TABLE IF EXISTS test_part_move_step_by_step SYNC;
             CREATE TABLE test_part_move_step_by_step(v UInt64)
             ENGINE ReplicatedMergeTree('/clickhouse/shard_{}/tables/test_part_move_step_by_step', '{}')
             ORDER BY tuple()
@@ -193,7 +193,7 @@ def test_part_move_step_by_step(started_cluster):
 
             r.query(
                 """
-            DROP TABLE IF EXISTS test_part_move_step_by_step_d;
+            DROP TABLE IF EXISTS test_part_move_step_by_step_d SYNC;
             CREATE TABLE test_part_move_step_by_step_d AS test_part_move_step_by_step
             ENGINE Distributed('test_cluster', currentDatabase(), test_part_move_step_by_step)
             """
@@ -300,7 +300,7 @@ def test_part_move_step_by_step_kill(started_cluster):
         for replica_ix, r in enumerate(rs):
             r.query(
                 """
-            DROP TABLE IF EXISTS test_part_move_step_by_step_kill;
+            DROP TABLE IF EXISTS test_part_move_step_by_step_kill SYNC;
             CREATE TABLE test_part_move_step_by_step_kill(v UInt64)
             ENGINE ReplicatedMergeTree('/clickhouse/shard_{}/tables/test_part_move_step_by_step_kill', '{}')
             ORDER BY tuple()
@@ -311,7 +311,7 @@ def test_part_move_step_by_step_kill(started_cluster):
 
             r.query(
                 """
-            DROP TABLE IF EXISTS test_part_move_step_by_step_kill_d;
+            DROP TABLE IF EXISTS test_part_move_step_by_step_kill_d SYNC;
             CREATE TABLE test_part_move_step_by_step_kill_d AS test_part_move_step_by_step_kill
             ENGINE Distributed('test_cluster', currentDatabase(), test_part_move_step_by_step_kill)
             """
@@ -446,7 +446,7 @@ def test_move_not_permitted(started_cluster):
     for ix, n in enumerate([s0r0, s1r0]):
         n.query(
             """
-        DROP TABLE IF EXISTS not_permitted_columns;
+        DROP TABLE IF EXISTS not_permitted_columns SYNC;
         
         CREATE TABLE not_permitted_columns(v_{ix} UInt64)
         ENGINE ReplicatedMergeTree('/clickhouse/shard_{ix}/tables/not_permitted_columns', 'r')
@@ -462,7 +462,7 @@ def test_move_not_permitted(started_cluster):
 
         n.query(
             """
-        DROP TABLE IF EXISTS not_permitted_partition;
+        DROP TABLE IF EXISTS not_permitted_partition SYNC;
         CREATE TABLE not_permitted_partition(date Date, v UInt64)
         ENGINE ReplicatedMergeTree('/clickhouse/shard_{ix}/tables/not_permitted_partition', 'r')
         PARTITION BY ({partition})

--- a/tests/integration/test_part_moves_between_shards/test.py
+++ b/tests/integration/test_part_moves_between_shards/test.py
@@ -239,10 +239,7 @@ def test_part_move_step_by_step(started_cluster):
     )
 
     # Should hang on SYNC_SOURCE until all source replicas acknowledge new pinned UUIDs.
-    wait_for_state(
-        "SYNC_SOURCE",
-        s0r0,
-        "test_part_move_step_by_step")
+    wait_for_state("SYNC_SOURCE", s0r0, "test_part_move_step_by_step")
     deduplication_invariant.assert_no_exception()
 
     # Start all replicas in source shard but stop a replica in destination shard
@@ -258,10 +255,7 @@ def test_part_move_step_by_step(started_cluster):
         "SYSTEM START MERGES test_part_move_step_by_step; OPTIMIZE TABLE test_part_move_step_by_step;"
     )
 
-    wait_for_state(
-        "SYNC_DESTINATION",
-        s0r0,
-        "test_part_move_step_by_step")
+    wait_for_state("SYNC_DESTINATION", s0r0, "test_part_move_step_by_step")
     deduplication_invariant.assert_no_exception()
 
     # Start previously stopped replica in destination shard to let SYNC_DESTINATION
@@ -269,10 +263,7 @@ def test_part_move_step_by_step(started_cluster):
     # Stop the other replica in destination shard to prevent DESTINATION_FETCH succeed.
     s1r0.stop_clickhouse()
     s1r1.start_clickhouse()
-    wait_for_state(
-        "DESTINATION_FETCH",
-        s0r0,
-        "test_part_move_step_by_step")
+    wait_for_state("DESTINATION_FETCH", s0r0, "test_part_move_step_by_step")
     deduplication_invariant.assert_no_exception()
 
     # Start previously stopped replica in destination shard to let DESTINATION_FETCH
@@ -280,20 +271,14 @@ def test_part_move_step_by_step(started_cluster):
     # Stop the other replica in destination shard to prevent DESTINATION_ATTACH succeed.
     s1r1.stop_clickhouse()
     s1r0.start_clickhouse()
-    wait_for_state(
-        "DESTINATION_ATTACH",
-        s0r0,
-        "test_part_move_step_by_step")
+    wait_for_state("DESTINATION_ATTACH", s0r0, "test_part_move_step_by_step")
     deduplication_invariant.assert_no_exception()
 
     # Start all replicas in destination shard to let DESTINATION_ATTACH succeed.
     # Stop a source replica to prevent SOURCE_DROP succeeding.
     s0r0.stop_clickhouse()
     s1r1.start_clickhouse()
-    wait_for_state(
-        "SOURCE_DROP",
-        s0r1,
-        "test_part_move_step_by_step")
+    wait_for_state("SOURCE_DROP", s0r1, "test_part_move_step_by_step")
     deduplication_invariant.assert_no_exception()
 
     s0r0.start_clickhouse()
@@ -378,10 +363,7 @@ def test_part_move_step_by_step_kill(started_cluster):
     )
 
     # Should hang on SYNC_SOURCE until all source replicas acknowledge new pinned UUIDs.
-    wait_for_state(
-        "SYNC_SOURCE",
-        s0r0,
-        "test_part_move_step_by_step_kill")
+    wait_for_state("SYNC_SOURCE", s0r0, "test_part_move_step_by_step_kill")
     deduplication_invariant.assert_no_exception()
 
     # Start all replicas in source shard but stop a replica in destination shard
@@ -397,10 +379,7 @@ def test_part_move_step_by_step_kill(started_cluster):
         "SYSTEM START MERGES test_part_move_step_by_step_kill; OPTIMIZE TABLE test_part_move_step_by_step_kill;"
     )
 
-    wait_for_state(
-        "SYNC_DESTINATION",
-        s0r0,
-        "test_part_move_step_by_step_kill" )
+    wait_for_state("SYNC_DESTINATION", s0r0, "test_part_move_step_by_step_kill" )
     deduplication_invariant.assert_no_exception()
 
     # Start previously stopped replica in destination shard to let SYNC_DESTINATION
@@ -408,20 +387,14 @@ def test_part_move_step_by_step_kill(started_cluster):
     # Stop the other replica in destination shard to prevent DESTINATION_FETCH succeed.
     s1r0.stop_clickhouse()
     s1r1.start_clickhouse()
-    wait_for_state(
-        "DESTINATION_FETCH",
-        s0r0,
-        "test_part_move_step_by_step_kill")
+    wait_for_state("DESTINATION_FETCH", s0r0, "test_part_move_step_by_step_kill")
 
     # Start previously stopped replica in destination shard to let DESTINATION_FETCH
     # succeed.
     # Stop the other replica in destination shard to prevent DESTINATION_ATTACH succeed.
     s1r1.stop_clickhouse()
     s1r0.start_clickhouse()
-    wait_for_state(
-        "DESTINATION_ATTACH",
-        s0r0,
-        "test_part_move_step_by_step_kill")
+    wait_for_state("DESTINATION_ATTACH", s0r0, "test_part_move_step_by_step_kill")
     deduplication_invariant.assert_no_exception()
 
     # Rollback here.
@@ -432,18 +405,11 @@ def test_part_move_step_by_step_kill(started_cluster):
     """
     )
 
-    wait_for_state(
-        "DESTINATION_ATTACH",
-        s0r0,
-        "test_part_move_step_by_step_kill",
-        assert_rollback=True
-    )
+    wait_for_state("DESTINATION_ATTACH", s0r0, "test_part_move_step_by_step_kill", assert_rollback=True)
 
     s1r1.start_clickhouse()
 
-    wait_for_state(
-        "CANCELLED", s0r0, "test_part_move_step_by_step_kill", assert_rollback=True
-    )
+    wait_for_state("CANCELLED", s0r0, "test_part_move_step_by_step_kill", assert_rollback=True)
     deduplication_invariant.assert_no_exception()
 
     # No hung tasks in replication queue. Would timeout otherwise.
@@ -626,3 +592,4 @@ class ConcurrentInvariant:
     def _assert_started(self):
         if not self.started:
             raise Exception("invariant thread not started, forgot to call start?")
+        

--- a/tests/integration/test_part_moves_between_shards/test.py
+++ b/tests/integration/test_part_moves_between_shards/test.py
@@ -512,10 +512,6 @@ def test_move_not_permitted(started_cluster):
             "ALTER TABLE not_permitted_partition MOVE PART '20210903_0_0_0' TO SHARD '/clickhouse/shard_1/tables/not_permitted_partition'"
         )
 
-    for shard_ix, rs in enumerate([[s0r0, s0r1], [s1r0, s1r1]]):
-        for replica_ix, r in enumerate(rs):
-            r.query("DROP TABLE not_permitted_partition SYNC")
-
 def wait_for_state(
     desired_state,
     instance,

--- a/tests/queries/0_stateless/01700_system_zookeeper_path_in.reference
+++ b/tests/queries/0_stateless/01700_system_zookeeper_path_in.reference
@@ -14,3 +14,5 @@ abandonable_lock-other
 failed_parts
 last_part
 parallel
+task_queue
+tasks

--- a/tests/queries/0_stateless/02221_system_zookeeper_unrestricted.reference
+++ b/tests/queries/0_stateless/02221_system_zookeeper_unrestricted.reference
@@ -76,6 +76,10 @@ shared
 shared
 table_shared_id
 table_shared_id
+task_queue
+task_queue
+tasks
+tasks
 temp
 temp
 zero_copy_hdfs

--- a/tests/queries/0_stateless/02221_system_zookeeper_unrestricted_like.reference
+++ b/tests/queries/0_stateless/02221_system_zookeeper_unrestricted_like.reference
@@ -37,6 +37,8 @@ replicas
 shared
 shared
 table_shared_id
+task_queue
+tasks
 temp
 zero_copy_hdfs
 zero_copy_s3
@@ -80,6 +82,8 @@ replicas
 shared
 shared
 table_shared_id
+task_queue
+tasks
 temp
 zero_copy_hdfs
 zero_copy_s3


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Implements [65633](https://github.com/ClickHouse/ClickHouse/issues/65633)

This is an Improvement of the existing experimental feature "Move Part Between Shards" The [base PR](https://github.com/ClickHouse/ClickHouse/pull/17871) was merged to master but it was marked as experimental due to some flakey tests and Implementation issues. 

The idea is to make incremental changes to this feature, till we are satisfied. But leave it in a better and working state for every improvement. 

In this PR I handled the below cases

1. Implement signals: Instead of waiting for replicas to execute the instruction, We use signals similar to quorum. The replicas executing the task signal the orchestrator thread through the `/task_queue` path once a full quorum is reached
2. I do not see any way to handle duplicates where the read query started before command execution and going on when this migration is happening. So, I added the change from this [PR](https://github.com/ClickHouse/ClickHouse/pull/50777) it stalls the move parts till existing operations are finished. 

Outstanding tasks for the next PR

1. Implement clean-up to remove the DONE/CANCELLED tasks from the zookeeper path above a particular age (similar to the mutations clean-up thread)
2. Do we want to use block-hash as an identifier for the part instead of UUID? but I am not sure if this will lead to conflicts if there are data repeats. But it might not negatively impact too much, just the merges, mutations will be delayed on these parts